### PR TITLE
Unexpected internal error near index 1

### DIFF
--- a/src/main/java/org/wildfly/swarm/plugin/BootstrapMarker.java
+++ b/src/main/java/org/wildfly/swarm/plugin/BootstrapMarker.java
@@ -112,7 +112,7 @@ public class BootstrapMarker {
 
     private void createBootstrapMarker(Path modulePath, String moduleName) throws IOException {
         if (moduleName == null) {
-            moduleName = modulePath.toString().replaceAll(File.separator, ".");
+            moduleName = modulePath.toString().replace(File.separator, ".");
             this.log.info("Using " + moduleName + " as conventional bootstrap module name");
         }
 


### PR DESCRIPTION
replaceAll expects a regex, when replacing all occurrences of a string, use replace() instead.
