### PR TITLE
SWARM-749: Support inclusion of modules in module-rewrite.conf

### DIFF
--- a/src/main/java/org/wildfly/swarm/plugin/FractionMetadata.java
+++ b/src/main/java/org/wildfly/swarm/plugin/FractionMetadata.java
@@ -43,7 +43,7 @@ public class FractionMetadata extends DependencyMetadata {
                 || isInternal()
                 || isBootstrap()
                 || this.stabilityIndex != null
-                || hasJavaFraction() ) {
+                || hasJavaFraction()) {
             return true;
         }
 
@@ -69,11 +69,11 @@ public class FractionMetadata extends DependencyMetadata {
 
     @JsonProperty("tags")
     public String getTagsString() {
-        if ( this.tags.isEmpty() ) {
+        if (this.tags.isEmpty()) {
             return "";
         }
 
-        return String.join( ",", this.tags);
+        return String.join(",", this.tags);
     }
 
     public void setTags(List<String> tags) {
@@ -153,13 +153,13 @@ public class FractionMetadata extends DependencyMetadata {
 
     @JsonIgnore
     public String getModule() {
-        if ( this.bootstrap != null ) {
-            if ( this.bootstrap.equals( "false" ) ) {
+        if (this.bootstrap != null) {
+            if (this.bootstrap.equals("false")) {
                 return null;
             }
             return this.bootstrap;
         }
-        return this.baseModulePath.toString().replace(File.separatorChar, '.' );
+        return this.baseModulePath.toString().replace(File.separatorChar, '.');
     }
 
     public void setDescription(String description) {
@@ -172,7 +172,7 @@ public class FractionMetadata extends DependencyMetadata {
 
     @JsonIgnore
     public StabilityLevel getStabilityIndex() {
-        if ( this.stabilityIndex == null ) {
+        if (this.stabilityIndex == null) {
             return StabilityLevel.UNSTABLE;
         }
         return this.stabilityIndex;

--- a/src/main/java/org/wildfly/swarm/plugin/process/ModuleRewriteConf.java
+++ b/src/main/java/org/wildfly/swarm/plugin/process/ModuleRewriteConf.java
@@ -123,6 +123,17 @@ public class ModuleRewriteConf {
                         current = new ModuleRewriteRules(name, slot);
                         this.rules.put(name + ":" + slot, current);
                     }
+                } else if (line.startsWith(INCLUDE)) {
+                    String name = null;
+                    String slot = null;
+
+                    String[] parts = line.substring(INCLUDE.length()).trim().split(":");
+                    name = parts[0];
+                    if (parts.length > 1) {
+                        slot = parts[1];
+                    }
+
+                    current.include(name, slot);
                 } else {
                     System.err.println(lineNumber + ":Lines should blank, or start with " + MODULE + " or " + OPTIONAL + ": " + line);
                 }
@@ -133,6 +144,8 @@ public class ModuleRewriteConf {
     private static final String MODULE = "module:";
 
     private static final String OPTIONAL = "optional:";
+
+    private static final String INCLUDE = "include:";
 
     private static final String REPLACE = "replace:";
 


### PR DESCRIPTION
## Motivation

People forget adding module dependencies in WildFly and it would be nice to have them added in the module.xml descriptor
## Modifications

Support include: keyword in module-rewrite.conf
## Result

The module dependency is added
