### PR TITLE
SWARM-688: Hide internal fractions on container startup

### DIFF
--- a/src/main/java/org/wildfly/swarm/plugin/process/FractionManifestGenerator.java
+++ b/src/main/java/org/wildfly/swarm/plugin/process/FractionManifestGenerator.java
@@ -59,6 +59,7 @@ public class FractionManifestGenerator implements Function<FractionMetadata, Fra
                 put("level", meta.getStabilityIndex().toString());
                 put("index", meta.getStabilityIndex().ordinal());
             }});
+            put("internal", meta.isInternal());
             put("dependencies",
                     meta.getDependencies()
                             .stream()


### PR DESCRIPTION
Motivation
----------
There's no need, by default, to show all the internal fractions that are installed in the container.

Modifications
-------------
Add flag indicating if fraction is internal only into the manifest

Result
------
`internal` is added to manifest for fractions