### PR TITLE
SWARM-1023: Arquillian should always be in BOM

### DIFF
--- a/src/main/java/org/wildfly/swarm/plugin/AbstractFractionsMojo.java
+++ b/src/main/java/org/wildfly/swarm/plugin/AbstractFractionsMojo.java
@@ -58,6 +58,7 @@ public abstract class AbstractFractionsMojo extends AbstractMojo {
             PROBABLY_FRACTIONS = this.project.getDependencyManagement().getDependencies()
                     .stream()
                     .filter(this::isSwarmProject)
+                    .filter(this::isNotArquillianArtifact)
                     .map(this::toProject)
                     .collect(Collectors.toList());
         }
@@ -97,6 +98,14 @@ public abstract class AbstractFractionsMojo extends AbstractMojo {
 
     protected boolean isSwarmProject(Dependency dependency) {
         return dependency.getGroupId().startsWith( "org.wildfly.swarm" );
+    }
+
+    protected boolean isNotArquillianArtifact(Dependency dependency) {
+        return !dependency.getArtifactId().contains("arquillian");
+    }
+
+    protected FractionMetadata arquillianFraction(String version) {
+        return new FractionMetadata("org.wildfly.swarm", "arquillian", version);
     }
 
     @Inject

--- a/src/main/java/org/wildfly/swarm/plugin/bom/BomMojo.java
+++ b/src/main/java/org/wildfly/swarm/plugin/bom/BomMojo.java
@@ -68,6 +68,7 @@ public class BomMojo extends AbstractFractionsMojo {
         List<DependencyMetadata> bomItems = new ArrayList<>();
         bomItems.addAll( fractions );
         bomItems.addAll( FractionRegistry.INSTANCE.bomInclusions() );
+        bomItems.add(arquillianFraction(this.project.getVersion()));
 
         final Path bomPath = Paths.get(this.project.getBuild().getOutputDirectory(), "bom.pom");
         try {


### PR DESCRIPTION
Motivation
----------
Currently the Arquillian fraction is only added to a BOM based on its stability. However, we really want Arquillian to be present in every BOM for testing.

This also allows us to decouple the Arquillian build from fraction-list.

Modifications
-------------
Exclude Arquillian from list of possible fractions to include in a BOM, and then add it directly without resolving it in.

Result
------
Arquillian is now in all BOM irrespective of its stability.