### PR TITLE
SWARM-866 - Surface configurable through --config-help

### DIFF
--- a/src/main/java/org/wildfly/swarm/plugin/process/ConfigurableDocumentationGenerator.java
+++ b/src/main/java/org/wildfly/swarm/plugin/process/ConfigurableDocumentationGenerator.java
@@ -1,0 +1,205 @@
+package org.wildfly.swarm.plugin.process;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.function.Function;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.CompositeIndex;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.IndexReader;
+import org.jboss.jandex.IndexView;
+import org.jboss.jandex.Indexer;
+import org.wildfly.swarm.plugin.FractionMetadata;
+import org.wildfly.swarm.plugin.process.configurable.AnnotationDocumentationGatherer;
+import org.wildfly.swarm.plugin.process.configurable.DocumentationRegistry;
+import org.wildfly.swarm.plugin.process.configurable.ResourceDocumentationGatherer;
+
+/**
+ * @author Bob McWhirter
+ */
+public class ConfigurableDocumentationGenerator implements Function<FractionMetadata, FractionMetadata> {
+    public static final DotName FRACTION_CLASS = DotName.createSimple("org.wildfly.swarm.spi.api.Fraction");
+
+    public static final DotName CONFIGURABLE_ANNOTATION = DotName.createSimple("org.wildfly.swarm.spi.api.annotations.Configurable");
+
+    public static final DotName SINGLETON_RESOURCE_ANNOTATION = DotName.createSimple("org.wildfly.swarm.config.runtime.SingletonResource");
+
+    public static final DotName ATTRIBUTE_DOCUMENTATION_ANNOTATION = DotName.createSimple("org.wildfly.swarm.config.runtime.AttributeDocumentation");
+
+    public static final DotName RESOURCE_DOCUMENTATION_ANNOTATION = DotName.createSimple("org.wildfly.swarm.config.runtime.ResourceDocumentation");
+
+    private final Path classesDir;
+
+    private final MavenProject project;
+
+    private final DocumentationRegistry documentationRegistry;
+
+    private final Log log;
+
+    public ConfigurableDocumentationGenerator(Log log, MavenProject project, File classesDir) {
+        this.log = log;
+        this.project = project;
+        this.classesDir = classesDir.toPath();
+        this.documentationRegistry = new DocumentationRegistry();
+    }
+
+    @Override
+    public FractionMetadata apply(FractionMetadata meta) {
+        if (!meta.hasJavaCode()) {
+            return meta;
+        }
+
+        if (!Files.exists(this.classesDir)) {
+            return meta;
+        }
+
+        final Path idx = this.classesDir.resolve("META-INF").resolve(Jandexer.INDEX_NAME);
+
+        if (!Files.exists(idx)) {
+            return meta;
+        }
+
+        IndexView ownIndex = loadOwnIndex();
+        IndexView totalIndex = buildIndex(ownIndex);
+
+        process(ownIndex, totalIndex);
+
+        //this.documentationRegistry.dump();
+        Properties props = this.documentationRegistry.asProperties();
+        props.setProperty("fraction", meta.getName().toLowerCase());
+
+        Path docs = this.classesDir.resolve("META-INF").resolve("configuration-meta.properties");
+
+        try {
+            Files.createDirectories(docs.getParent());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        try (OutputStream out = new FileOutputStream(docs.toFile())) {
+            props.store(out, "Created by wildfly-swarm-fraction-plugin");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        return meta;
+    }
+
+    protected IndexView buildIndex(IndexView ownIndex) {
+        IndexView dependentIndexes = loadDependentIndexes();
+
+        return CompositeIndex.create(ownIndex, dependentIndexes);
+    }
+
+    protected IndexView loadOwnIndex() {
+        final Path idx = this.classesDir.resolve("META-INF").resolve(Jandexer.INDEX_NAME);
+
+        IndexView index = null;
+
+        if (Files.exists(idx)) {
+            try (InputStream in = new FileInputStream(idx.toFile())) {
+                index = loadIndex(in);
+            } catch (FileNotFoundException e) {
+                e.printStackTrace();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+
+        return index;
+    }
+
+    protected IndexView loadDependentIndexes() {
+        List<IndexView> indexes = this.project.getArtifacts()
+                .stream()
+                .map(artifact -> {
+                    try {
+                        return loadIndex(artifact);
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    }
+                    return null;
+                })
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+
+        return CompositeIndex.create(indexes);
+    }
+
+    protected IndexView loadIndex(Artifact dep) throws IOException {
+        if (dep.getFile() == null) {
+            return null;
+        }
+
+        return loadDependentIndexFromArchive(dep.getFile());
+    }
+
+    protected IndexView loadDependentIndexFromArchive(File archive) throws IOException {
+        try (JarFile jar = new JarFile(archive)) {
+
+            ZipEntry entry = jar.getEntry("META-INF/" + Jandexer.INDEX_NAME);
+            if (entry != null) {
+                return loadIndex(jar.getInputStream(entry));
+
+            }
+            Indexer indexer = new Indexer();
+
+            Enumeration<JarEntry> entries = jar.entries();
+
+            while (entries.hasMoreElements()) {
+                JarEntry each = entries.nextElement();
+                if (each.getName().endsWith(".class")) {
+                    try (InputStream in = jar.getInputStream(each)) {
+                        indexer.index(in);
+                    }
+                }
+
+            }
+
+            return indexer.complete();
+        }
+    }
+
+    protected IndexView loadIndex(InputStream in) throws IOException {
+        IndexReader reader = new IndexReader(in);
+        return reader.read();
+    }
+
+    protected void process(IndexView ownIndex, IndexView totalIndex) {
+        Collection<ClassInfo> fractions = ownIndex.getAllKnownImplementors(FRACTION_CLASS);
+
+        for (ClassInfo fraction : fractions) {
+            new ResourceDocumentationGatherer(this.log, this.documentationRegistry, totalIndex, fraction).gather();
+        }
+
+        Collection<AnnotationInstance> annos = ownIndex.getAnnotations(CONFIGURABLE_ANNOTATION);
+
+        for (AnnotationInstance anno : annos) {
+            ClassInfo declaringClass = anno.target().asField().declaringClass();
+            if (!fractions.contains(declaringClass)) {
+                new AnnotationDocumentationGatherer(this.log, this.documentationRegistry, totalIndex, anno).gather();
+            }
+        }
+    }
+}

--- a/src/main/java/org/wildfly/swarm/plugin/process/Jandexer.java
+++ b/src/main/java/org/wildfly/swarm/plugin/process/Jandexer.java
@@ -25,7 +25,7 @@ import org.wildfly.swarm.plugin.FractionMetadata;
  */
 public class Jandexer implements Function<FractionMetadata, FractionMetadata> {
 
-    private static final String INDEX_NAME = "jandex.idx";
+    public static final String INDEX_NAME = "jandex.idx";
 
     public Jandexer(Log log, File classesDir) {
         this.log = log;

--- a/src/main/java/org/wildfly/swarm/plugin/process/ProcessMojo.java
+++ b/src/main/java/org/wildfly/swarm/plugin/process/ProcessMojo.java
@@ -59,6 +59,7 @@ public class ProcessMojo extends AbstractMojo {
         new ModuleFiller(getLog(), this.repositorySystemSession, this.resolver, this.project).apply(meta);
         new FractionManifestGenerator(getLog(), this.project).apply(meta);
         new Jandexer(getLog(), new File(this.project.getBuild().getOutputDirectory())).apply(meta);
+        new ConfigurableDocumentationGenerator(getLog(), this.project, new File(this.project.getBuild().getOutputDirectory())).apply(meta);
     }
 
     @Parameter(defaultValue = "${repositorySystemSession}", readonly = true)

--- a/src/main/java/org/wildfly/swarm/plugin/process/configurable/AnnotationDocumentationGatherer.java
+++ b/src/main/java/org/wildfly/swarm/plugin/process/configurable/AnnotationDocumentationGatherer.java
@@ -1,0 +1,34 @@
+package org.wildfly.swarm.plugin.process.configurable;
+
+import org.apache.maven.plugin.logging.Log;
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.FieldInfo;
+import org.jboss.jandex.IndexView;
+
+/**
+ * @author Bob McWhirter
+ */
+public class AnnotationDocumentationGatherer extends DocumentationGatherer {
+
+    private final AnnotationInstance anno;
+
+    public AnnotationDocumentationGatherer(Log log, DocumentationRegistry documentationRegistry, IndexView totalIndex, AnnotationInstance anno) {
+        super(log, documentationRegistry, totalIndex);
+        this.anno = anno;
+    }
+
+    @Override
+    public void gather() {
+        String name = this.anno.value().asString();
+        FieldInfo target = this.anno.target().asField();
+
+        String docs = "(not yet documented)";
+        if (isMarkedAsDocumented(target)) {
+            docs = getDocumentation(this.anno.target().asField());
+        } else {
+            getLog().warn("Missing @AttributeDocumentation: " + target.declaringClass().name() + "#" + target.name());
+        }
+
+        addDocumentation(name, docs);
+    }
+}

--- a/src/main/java/org/wildfly/swarm/plugin/process/configurable/DocumentationGatherer.java
+++ b/src/main/java/org/wildfly/swarm/plugin/process/configurable/DocumentationGatherer.java
@@ -1,0 +1,140 @@
+package org.wildfly.swarm.plugin.process.configurable;
+
+import java.util.Collection;
+
+import org.apache.maven.plugin.logging.Log;
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.FieldInfo;
+import org.jboss.jandex.IndexView;
+import org.wildfly.swarm.plugin.process.ConfigurableDocumentationGenerator;
+
+/**
+ * @author Bob McWhirter
+ */
+public abstract class DocumentationGatherer {
+
+    protected final DocumentationRegistry registry;
+
+    protected final IndexView index;
+
+    private final Log log;
+
+    public DocumentationGatherer(Log log, DocumentationRegistry registry, IndexView index) {
+        this.log = log;
+        this.registry = registry;
+        this.index = index;
+    }
+
+    protected Log getLog() {
+        return this.log;
+    }
+
+    protected void addDocumentation(String key, String docs) {
+        this.registry.add(key, docs);
+    }
+
+    protected ClassInfo getClassByName(DotName name) {
+        return this.index.getClassByName(name);
+    }
+
+    protected String dashize(String name) {
+        int numChars = name.length();
+
+        StringBuilder str = new StringBuilder();
+
+        for (int i = 0; i < numChars; ++i) {
+            char c = name.charAt(i);
+
+            if (i == 0) {
+                str.append(c);
+            } else if (Character.isUpperCase(c)) {
+                str.append("-");
+                str.append(Character.toLowerCase(c));
+            } else {
+                str.append(c);
+            }
+        }
+
+        return str.toString();
+    }
+
+    protected static boolean isMarkedAsConfigurable(FieldInfo field) {
+        for (AnnotationInstance anno : field.annotations()) {
+            if (anno.name().equals(ConfigurableDocumentationGenerator.CONFIGURABLE_ANNOTATION)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected static String getConfigurableName(FieldInfo field) {
+        for (AnnotationInstance anno : field.annotations()) {
+            if (anno.name().equals(ConfigurableDocumentationGenerator.CONFIGURABLE_ANNOTATION)) {
+                return anno.value().asString();
+            }
+        }
+
+        return null;
+    }
+
+    protected static boolean isMarkedAsDocumented(FieldInfo field) {
+        for (AnnotationInstance anno : field.annotations()) {
+            if (anno.name().equals(ConfigurableDocumentationGenerator.ATTRIBUTE_DOCUMENTATION_ANNOTATION)) {
+                return true;
+            }
+            if (anno.name().equals(ConfigurableDocumentationGenerator.RESOURCE_DOCUMENTATION_ANNOTATION)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected static boolean isSingletonResource(FieldInfo field) {
+        for (AnnotationInstance anno : field.annotations()) {
+            if (anno.name().equals(ConfigurableDocumentationGenerator.SINGLETON_RESOURCE_ANNOTATION)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected static boolean isSubresources(FieldInfo field) {
+        return field.name().equals("subresources");
+    }
+
+    protected static String getDocumentation(FieldInfo field) {
+        for (AnnotationInstance anno : field.annotations()) {
+            if (anno.name().equals(ConfigurableDocumentationGenerator.ATTRIBUTE_DOCUMENTATION_ANNOTATION)) {
+                return anno.value().asString();
+            }
+            if (anno.name().equals(ConfigurableDocumentationGenerator.RESOURCE_DOCUMENTATION_ANNOTATION)) {
+                return anno.value().asString();
+            }
+        }
+        return "";
+    }
+
+    protected static String simpleNameFor(ClassInfo fraction) {
+        Collection<AnnotationInstance> annos = fraction.classAnnotations();
+
+        for (AnnotationInstance anno : annos) {
+            if (anno.name().equals(ConfigurableDocumentationGenerator.CONFIGURABLE_ANNOTATION)) {
+                if (anno.value() != null) {
+                    return anno.value().asString();
+                }
+            }
+        }
+
+        String name = fraction.name().local();
+        return name.replace("Fraction", "").toLowerCase();
+    }
+
+    public abstract void gather();
+}
+
+

--- a/src/main/java/org/wildfly/swarm/plugin/process/configurable/DocumentationItem.java
+++ b/src/main/java/org/wildfly/swarm/plugin/process/configurable/DocumentationItem.java
@@ -1,0 +1,7 @@
+package org.wildfly.swarm.plugin.process.configurable;
+
+/**
+ * @author Bob McWhirter
+ */
+public class DocumentationItem {
+}

--- a/src/main/java/org/wildfly/swarm/plugin/process/configurable/DocumentationRegistry.java
+++ b/src/main/java/org/wildfly/swarm/plugin/process/configurable/DocumentationRegistry.java
@@ -1,0 +1,42 @@
+package org.wildfly.swarm.plugin.process.configurable;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * @author Bob McWhirter
+ */
+public class DocumentationRegistry {
+
+    public DocumentationRegistry() {
+
+    }
+
+    public void add(String key, String docs) {
+        this.registry.put(key, docs);
+    }
+
+    public String toString() {
+        return registry.toString();
+    }
+
+    public void dump() {
+        this.registry.keySet().stream().sorted()
+                .forEach(key -> {
+                    System.err.println(key + ": " + this.registry.get(key));
+                });
+    }
+
+    public Properties asProperties() {
+        Properties props = new Properties();
+        this.registry.keySet().stream().sorted()
+                .forEach(key -> {
+                    props.setProperty(key, this.registry.get(key));
+                });
+
+        return props;
+    }
+
+    private Map<String, String> registry = new HashMap<>();
+}

--- a/src/main/java/org/wildfly/swarm/plugin/process/configurable/ResourceDocumentationGatherer.java
+++ b/src/main/java/org/wildfly/swarm/plugin/process/configurable/ResourceDocumentationGatherer.java
@@ -1,0 +1,85 @@
+package org.wildfly.swarm.plugin.process.configurable;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.maven.plugin.logging.Log;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.FieldInfo;
+import org.jboss.jandex.IndexView;
+
+/**
+ * @author Bob McWhirter
+ */
+public class ResourceDocumentationGatherer extends DocumentationGatherer {
+
+    private final ClassInfo resourceClassInfo;
+
+    private final String name;
+
+    private boolean isRootFraction;
+
+    private static final Set<String> IGNORABLE_FIELDS = new HashSet<String>() {{
+        add("pcs");
+        add("key");
+    }};
+
+    public ResourceDocumentationGatherer(Log log, DocumentationRegistry registry, IndexView index, ClassInfo resourceClassInfo) {
+        this(log, "swarm." + simpleNameFor(resourceClassInfo), registry, index, resourceClassInfo);
+        this.isRootFraction = true;
+    }
+
+    public ResourceDocumentationGatherer(Log log, String name, DocumentationRegistry registry, IndexView index, ClassInfo resourceClassInfo) {
+        super(log, registry, index);
+        this.resourceClassInfo = resourceClassInfo;
+        this.name = name;
+        this.isRootFraction = false;
+    }
+
+    @Override
+    public void gather() {
+        process(this.resourceClassInfo);
+    }
+
+    protected void process(ClassInfo current) {
+        List<FieldInfo> fields = current.fields();
+
+        for (FieldInfo field : fields) {
+            process(field);
+        }
+
+        ClassInfo superClass = getClassByName(current.superName());//index.getClassByName(current.superName());
+
+        if (superClass != null) {
+            process(superClass);
+        }
+    }
+
+    protected void process(FieldInfo field) {
+        if (isSubresources(field)) {
+            ClassInfo subresourceInfo = getClassByName(field.type().name());
+            new SubresourcesDocumentationGatherer(getLog(), this.registry, this.index, this.name, subresourceInfo).gather();
+        } else {
+            if (IGNORABLE_FIELDS.contains(field.name())) {
+                return;
+            }
+            if (this.isRootFraction) {
+                String name = this.name + "." + dashize(field.name());
+                String docs = "(not yet documented)";
+                if (isMarkedAsConfigurable(field)) {
+                    name = getConfigurableName(field);
+                }
+                if (isMarkedAsDocumented(field)) {
+                    docs = getDocumentation(field);
+                } else {
+                    getLog().warn("Missing @AttributeDocumentation: " + this.resourceClassInfo.name() + "#" + field.name());
+
+                }
+                addDocumentation(name, docs);
+            } else if (isMarkedAsDocumented(field)) {
+                addDocumentation(this.name + "." + dashize(field.name()), getDocumentation(field));
+            }
+        }
+    }
+}

--- a/src/main/java/org/wildfly/swarm/plugin/process/configurable/SubresourcesDocumentationGatherer.java
+++ b/src/main/java/org/wildfly/swarm/plugin/process/configurable/SubresourcesDocumentationGatherer.java
@@ -1,0 +1,50 @@
+package org.wildfly.swarm.plugin.process.configurable;
+
+import java.util.List;
+
+import org.apache.maven.plugin.logging.Log;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.FieldInfo;
+import org.jboss.jandex.IndexView;
+
+/**
+ * @author Bob McWhirter
+ */
+public class SubresourcesDocumentationGatherer extends DocumentationGatherer {
+
+    private final String name;
+
+    private final ClassInfo subresourceInfo;
+
+
+    public SubresourcesDocumentationGatherer(Log log, DocumentationRegistry registry, IndexView index, String name, ClassInfo subresourceInfo) {
+        super(log, registry, index);
+        this.name = name;
+        this.subresourceInfo = subresourceInfo;
+    }
+
+    @Override
+    public void gather() {
+        List<FieldInfo> fields = this.subresourceInfo.fields();
+
+        for (FieldInfo field : fields) {
+            if (isMarkedAsDocumented(field)) {
+                String docs = getDocumentation(field);
+
+                String name = this.name + "." + dashize(field.name());
+
+                ClassInfo nextClassInfo = null;
+
+                if (!isSingletonResource(field)) {
+                    name = name + ".*";
+                    nextClassInfo = getClassByName(field.type().asParameterizedType().arguments().get(0).name());
+                } else {
+                    nextClassInfo = getClassByName(field.type().name());
+                }
+
+
+                new ResourceDocumentationGatherer(getLog(), name, this.registry, this.index, nextClassInfo).gather();
+            }
+        }
+    }
+}


### PR DESCRIPTION
The plugin looks at the new config-api annotations and generates
a META-INF/configurable-meta.properties for each fraction to
provide key (or pattern) to documentation mappings.