### PR TITLE
SWARM-974: Auto Detection enhancements

### DIFF
--- a/src/main/java/org/wildfly/swarm/plugin/AbstractFractionsMojo.java
+++ b/src/main/java/org/wildfly/swarm/plugin/AbstractFractionsMojo.java
@@ -25,6 +25,7 @@ import javax.inject.Inject;
 
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.DefaultProjectBuildingRequest;
 import org.apache.maven.project.MavenProject;
@@ -43,7 +44,7 @@ public abstract class AbstractFractionsMojo extends AbstractMojo {
 
     private static List<MavenProject> PROBABLE_FRACTIONS = null;
 
-    private List<MavenProject> probableFractionProjects() {
+    private List<MavenProject> probableFractionProjects() throws MojoExecutionException {
         if (PROBABLE_FRACTIONS == null) {
 
             final ProjectBuildingRequest request = new DefaultProjectBuildingRequest();
@@ -61,14 +62,14 @@ public abstract class AbstractFractionsMojo extends AbstractMojo {
                         .map(ProjectBuildingResult::getProject)
                         .collect(Collectors.toList());
             } catch (ProjectBuildingException e) {
-                getLog().error(e);
+                throw new MojoExecutionException("Error generating list of PROBABLE_FRACTIONS", e);
             }
         }
 
         return PROBABLE_FRACTIONS;
     }
 
-    protected synchronized Set<FractionMetadata> fractions() {
+    protected synchronized Set<FractionMetadata> fractions() throws MojoExecutionException {
         return probableFractionProjects()
                 .stream()
                 .map(FractionRegistry.INSTANCE::of)

--- a/src/main/java/org/wildfly/swarm/plugin/AbstractFractionsMojo.java
+++ b/src/main/java/org/wildfly/swarm/plugin/AbstractFractionsMojo.java
@@ -15,6 +15,7 @@
  */
 package org.wildfly.swarm.plugin;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -22,8 +23,6 @@ import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
-import org.apache.maven.artifact.Artifact;
-import org.apache.maven.artifact.handler.DefaultArtifactHandler;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -32,6 +31,7 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuilder;
 import org.apache.maven.project.ProjectBuildingException;
 import org.apache.maven.project.ProjectBuildingRequest;
+import org.apache.maven.project.ProjectBuildingResult;
 import org.eclipse.aether.DefaultRepositorySystemSession;
 
 /**
@@ -41,27 +41,34 @@ import org.eclipse.aether.DefaultRepositorySystemSession;
  */
 public abstract class AbstractFractionsMojo extends AbstractMojo {
 
-    protected static final String FRACTION_TAGS_PROPERTY_NAME = "swarm.fraction.tags";
-
-    protected static final String FRACTION_INTERNAL_PROPERTY_NAME = "swarm.fraction.internal";
-
     private static List<MavenProject> PROBABLE_FRACTIONS = null;
 
-    public List<MavenProject> probableFractionProjects() {
+    private List<MavenProject> probableFractionProjects() {
         if (PROBABLE_FRACTIONS == null) {
 
-            PROBABLE_FRACTIONS = this.project.getDependencyManagement().getDependencies()
-                    .stream()
-                    .filter(this::isSwarmProject)
-                    .filter(this::isNotArquillianArtifact)
-                    .map(this::toProject)
-                    .collect(Collectors.toList());
+            final ProjectBuildingRequest request = new DefaultProjectBuildingRequest();
+            request.setProcessPlugins(false);
+            request.setSystemProperties(System.getProperties());
+            request.setRemoteRepositories(this.project.getRemoteArtifactRepositories());
+            request.setRepositorySession(this.repositorySystemSession);
+            request.setResolveDependencies(true);
+
+            try {
+                PROBABLE_FRACTIONS = this.projectBuilder
+                        .build(Collections.singletonList(findRoot(this.project).getFile()), true, request)
+                        .stream()
+                        .filter(this::isNotArquillianArtifact)
+                        .map(ProjectBuildingResult::getProject)
+                        .collect(Collectors.toList());
+            } catch (ProjectBuildingException e) {
+                getLog().error(e);
+            }
         }
 
         return PROBABLE_FRACTIONS;
     }
 
-    public synchronized Set<FractionMetadata> fractions() {
+    protected synchronized Set<FractionMetadata> fractions() {
         return probableFractionProjects()
                 .stream()
                 .map(FractionRegistry.INSTANCE::of)
@@ -69,34 +76,19 @@ public abstract class AbstractFractionsMojo extends AbstractMojo {
                 .collect(Collectors.toSet());
     }
 
-    protected MavenProject toProject(Dependency dependency) {
-        try {
-            return project(dependency);
-        } catch (ProjectBuildingException e) {
-            return null;
+    protected MavenProject findRoot(MavenProject current) {
+        if (current.getArtifactId().equals("wildfly-swarm")) {
+            return current;
         }
-    }
-
-    protected MavenProject project(final Dependency dependency) throws ProjectBuildingException {
-        final ProjectBuildingRequest request = new DefaultProjectBuildingRequest();
-        request.setProcessPlugins(false);
-        request.setSystemProperties(System.getProperties());
-        request.setRemoteRepositories(this.project.getRemoteArtifactRepositories());
-        request.setRepositorySession(this.repositorySystemSession);
-        request.setResolveDependencies(true);
-        final Artifact artifact =
-                new org.apache.maven.artifact.DefaultArtifact(dependency.getGroupId(), dependency.getArtifactId(),
-                                                              dependency.getVersion(), "compile", "", "",
-                                                              new DefaultArtifactHandler());
-        return projectBuilder.build(artifact, request).getProject();
+        return findRoot(current.getParent());
     }
 
     protected boolean isSwarmProject(Dependency dependency) {
         return dependency.getGroupId().startsWith("org.wildfly.swarm");
     }
 
-    protected boolean isNotArquillianArtifact(Dependency dependency) {
-        return !dependency.getArtifactId().contains("arquillian");
+    protected boolean isNotArquillianArtifact(ProjectBuildingResult result) {
+        return !result.getProject().getArtifactId().contains("arquillian");
     }
 
     protected FractionMetadata arquillianFraction(String version) {

--- a/src/main/java/org/wildfly/swarm/plugin/FractionMetadata.java
+++ b/src/main/java/org/wildfly/swarm/plugin/FractionMetadata.java
@@ -18,8 +18,10 @@ package org.wildfly.swarm.plugin;
 import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -29,6 +31,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * @author Bob McWhirter
+ * @author Ken Finnigan
  */
 public class FractionMetadata extends DependencyMetadata {
 
@@ -205,6 +208,15 @@ public class FractionMetadata extends DependencyMetadata {
                 .collect(Collectors.toSet());
     }
 
+    public void addDetectorClass(Path relativePath, Path detectorClassPath) {
+        this.detectorClasses.put(relativePath, detectorClassPath);
+    }
+
+    @JsonIgnore
+    public Map<Path, Path> getDetectorClasses() {
+        return this.detectorClasses;
+    }
+
     public String toString() {
         return getGroupId() + ":" + getArtifactId() + ":" + this.getVersion();
     }
@@ -234,6 +246,8 @@ public class FractionMetadata extends DependencyMetadata {
     private boolean hasJavaCode;
 
     private final Set<DependencyMetadata> dependencies = new HashSet<>();
+
+    private final Map<Path, Path> detectorClasses = new HashMap<>();
 
     // 2 = Unstable
     private StabilityLevel stabilityIndex = null;

--- a/src/main/java/org/wildfly/swarm/plugin/FractionRegistry.java
+++ b/src/main/java/org/wildfly/swarm/plugin/FractionRegistry.java
@@ -179,7 +179,7 @@ public class FractionRegistry {
                     }
                 });
             } catch (IOException e) {
-                //ignore
+                e.printStackTrace();
             }
         }
     }

--- a/src/main/java/org/wildfly/swarm/plugin/fractionlist/FractionListMojo.java
+++ b/src/main/java/org/wildfly/swarm/plugin/fractionlist/FractionListMojo.java
@@ -75,7 +75,7 @@ public class FractionListMojo extends AbstractFractionsMojo {
                 out.write("\n");
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            getLog().error(e);
         }
 
         org.apache.maven.artifact.DefaultArtifact artifact = new org.apache.maven.artifact.DefaultArtifact(
@@ -135,9 +135,8 @@ public class FractionListMojo extends AbstractFractionsMojo {
 
             writer.write(";");
             writer.flush();
-            writer.close();
         } catch (IOException e) {
-            e.printStackTrace();
+            getLog().error(e);
         }
 
         org.apache.maven.artifact.DefaultArtifact artifact = new org.apache.maven.artifact.DefaultArtifact(
@@ -199,7 +198,6 @@ public class FractionListMojo extends AbstractFractionsMojo {
                     });
 
             writer.flush();
-            writer.close();
         } catch (IOException e) {
             getLog().error(e);
         }

--- a/src/main/java/org/wildfly/swarm/plugin/fractionlist/FractionListMojo.java
+++ b/src/main/java/org/wildfly/swarm/plugin/fractionlist/FractionListMojo.java
@@ -18,7 +18,11 @@ package org.wildfly.swarm.plugin.fractionlist;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -32,6 +36,8 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.wildfly.swarm.plugin.AbstractFractionsMojo;
 import org.wildfly.swarm.plugin.FractionMetadata;
+
+import static java.nio.file.Files.copy;
 
 /**
  * @author Bob McWhirter
@@ -52,6 +58,7 @@ public class FractionListMojo extends AbstractFractionsMojo {
         generateTxt(fractions);
         generateJSON(fractions);
         generateJavascript(fractions);
+        extractDetectors(fractions);
     }
 
     private void generateTxt(Set<FractionMetadata> fractions) {
@@ -145,6 +152,58 @@ public class FractionListMojo extends AbstractFractionsMojo {
 
         artifact.setFile(outFile);
         this.project.addAttachedArtifact(artifact);
+    }
+
+    private void extractDetectors(Set<FractionMetadata> fractions) {
+        Path buildDir = Paths.get(this.project.getBuild().getOutputDirectory());
+
+        Set<FractionMetadata> fractionsWithDetectors = fractions.stream()
+                .filter(f -> f.getDetectorClasses().size() > 0)
+                .collect(Collectors.toSet());
+
+        fractionsWithDetectors
+                .forEach(f -> {
+                    f.getDetectorClasses().forEach((relative, full) -> {
+                        try {
+                            Path target = buildDir.resolve(relative);
+                            File targetFile = target.toFile();
+                            if (!targetFile.exists()) {
+                                targetFile.getParentFile().mkdirs();
+                            }
+                            copy(full, target, StandardCopyOption.REPLACE_EXISTING);
+                        } catch (IOException e) {
+                            getLog().error(e);
+                        }
+                    });
+                });
+
+        String servicesFile = "META-INF" + File.separator + "services" + File.separator + "org.wildfly.swarm.spi.meta.FractionDetector";
+        File outFile = new File(this.project.getBuild().getOutputDirectory(), servicesFile);
+        if (!outFile.exists()) {
+            outFile.getParentFile().mkdirs();
+        }
+
+        try (FileWriter writer = new FileWriter(outFile)) {
+            fractionsWithDetectors
+                    .stream()
+                    .flatMap(f -> f.getDetectorClasses().keySet().stream())
+                    .map(p -> p.toString().substring(0, p.toString().lastIndexOf('.')))
+                    .map(s -> s.replace(File.separatorChar, '.'))
+                    .forEach(p -> {
+                        try {
+                            writer.write(p);
+                            writer.write("\n");
+                        } catch (IOException e) {
+                            getLog().error(e);
+                        }
+                    });
+
+            writer.flush();
+            writer.close();
+        } catch (IOException e) {
+            getLog().error(e);
+        }
+
     }
 
     @Parameter(defaultValue = "${project.version}", readonly = true)

--- a/src/main/java/org/wildfly/swarm/plugin/process/ModuleGenerator.java
+++ b/src/main/java/org/wildfly/swarm/plugin/process/ModuleGenerator.java
@@ -44,6 +44,8 @@ public class ModuleGenerator implements Function<FractionMetadata, FractionMetad
 
     private static final String DEPLOYMENT = "deployment";
 
+    private static final String DETECT = "detect";
+
     private static final String MODULE_XML = "module.xml";
 
     private static final String WELD_VERSION = "3";
@@ -329,7 +331,7 @@ public class ModuleGenerator implements Function<FractionMetadata, FractionMetad
     }
 
     private Set<String> determineApiPaths() throws IOException {
-        return determinePaths((file) -> (!(file.contains(RUNTIME) || file.contains(DEPLOYMENT))));
+        return determinePaths((file) -> (!(file.contains(RUNTIME) || file.contains(DEPLOYMENT) || file.contains(DETECT))));
     }
 
     private Set<String> determineRuntimePaths() throws IOException {


### PR DESCRIPTION
Motivation
----------
Enabling fraction auto detection to be handled through Java code instead of a properties file, and each fractions detection code is within the fraction itself.

Doing so means we need to exclude code in the `detect` package from being picked up by the :api or :runtime modules.

Modify FractionRegistry loading to locate whether a module has any `detect` classes so that the `fraction-list` goal can collect them all and add them to target/classes. Also generates a META-INF/services file listing all the detectors.

Modifications
-------------
Add detector classes to FractionMetadata, locate all detector classes in FractionRegistry, modify PROBABLY_FRACTIONS loading to walk up to the wildfly-swarm root pom and then load the MavenProject's from the root pom as opposed to recreating them from the pom.xml from the local M2 repo.

Result
------
Changes fraction lookup to use project structure instead of loaded from M2 repo, and adds handling for detectors