### PR TITLE
SWARM-1282 - Support "certified" community BOM in product

### DIFF
--- a/src/main/java/org/wildfly/swarm/plugin/bom/CertifiedBomMojo.java
+++ b/src/main/java/org/wildfly/swarm/plugin/bom/CertifiedBomMojo.java
@@ -15,13 +15,17 @@
  */
 package org.wildfly.swarm.plugin.bom;
 
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -31,46 +35,24 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
 import org.wildfly.swarm.plugin.AbstractFractionsMojo;
 import org.wildfly.swarm.plugin.DependencyMetadata;
 import org.wildfly.swarm.plugin.FractionMetadata;
-import org.wildfly.swarm.plugin.FractionRegistry;
 
-@Mojo(name = "generate-bom",
+@Mojo(name = "generate-certified-bom",
         defaultPhase = LifecyclePhase.PACKAGE)
-public class BomMojo extends AbstractFractionsMojo {
+public class CertifiedBomMojo extends AbstractFractionsMojo {
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
-        Set<FractionMetadata> allFractions = fractions();
+        Set<FractionMetadata> certifiedFractions = loadCertifiedMetadata();
 
-        Collection<FractionMetadata> fractions = null;
-
-        if (this.stabilityIndex != null) {
-            this.stabilityIndex = this.stabilityIndex.trim();
-            if (this.stabilityIndex.equals("*")) {
-                fractions = allFractions;
-            } else if (this.stabilityIndex.endsWith("+")) {
-                int level = Integer.parseInt(this.stabilityIndex.substring(0, this.stabilityIndex.length() - 1));
-                fractions = allFractions
-                        .stream()
-                        .filter((e) -> e.getStabilityIndex().ordinal() >= level)
-                        .collect(Collectors.toSet());
-            } else {
-                int level = Integer.parseInt(this.stabilityIndex);
-                fractions = allFractions
-                        .stream()
-                        .filter((e) -> e.getStabilityIndex().ordinal() == level)
-                        .collect(Collectors.toSet());
-            }
-        }
+        String certifiedVersion = certifiedFractions.stream().findFirst().get().getVersion();
 
         List<DependencyMetadata> bomItems = new ArrayList<>();
-        bomItems.addAll(fractions);
-        bomItems.addAll(FractionRegistry.INSTANCE.bomInclusions());
-        if (!this.product) {
-            bomItems.add(arquillianFraction(this.project.getVersion()));
-        }
+        bomItems.addAll(certifiedFractions);
+        bomItems.add(arquillianFraction(certifiedVersion));
 
         final Path bomPath = Paths.get(this.project.getBuild().getOutputDirectory(), "bom.pom");
         try {
@@ -83,11 +65,43 @@ public class BomMojo extends AbstractFractionsMojo {
 
         getLog().info(String.format("Wrote bom to %s", bomPath));
 
-        for (FractionMetadata each : fractions) {
+        for (FractionMetadata each : certifiedFractions) {
             getLog().info(String.format("%20s:%s", each.getGroupId(), each.getArtifactId()));
         }
 
         project.setFile(bomPath.toFile());
+    }
+
+    protected Set<FractionMetadata> loadCertifiedMetadata() throws MojoFailureException {
+        Path certifiedConf = new File(this.project.getBasedir(), "certified.conf").toPath();
+        try (BufferedReader in = new BufferedReader(new FileReader(certifiedConf.toFile()))) {
+            Set<String> certifiedFractions = in.lines()
+                    .collect(Collectors.toSet());
+
+            URL listUrl = getClass().getResource("/fraction-list.txt");
+
+            try (BufferedReader listIn = new BufferedReader(new InputStreamReader(listUrl.openStream()))) {
+                return listIn.lines()
+                        .map(e -> {
+                            String[] parts = e.split("=");
+                            return parts[0].trim();
+                        })
+                        .map(e -> {
+                            String[] parts = e.split(":");
+                            return new FractionMetadata(parts[0], parts[1], parts[2]);
+                        })
+                        .filter(e -> {
+                            return certifiedFractions.contains(e.getArtifactId());
+                        })
+                        .collect(Collectors.toSet());
+            }
+        } catch (IOException e) {
+            throw new MojoFailureException("Unable to read fraction-list.txt", e);
+        }
+    }
+
+    protected Set<FractionMetadata> certifiedFractions() {
+        return Collections.emptySet();
     }
 
     private String readTemplate() throws MojoFailureException {
@@ -102,11 +116,8 @@ public class BomMojo extends AbstractFractionsMojo {
         }
     }
 
-    @Parameter
-    private String stabilityIndex;
-
-    @Parameter(defaultValue = "${swarm.product.build}")
-    private boolean product;
+    @Parameter(defaultValue = "${project}", readonly = true)
+    public MavenProject project;
 
     @Parameter
     private File template;


### PR DESCRIPTION
Motivation:

We don't want to productize everything, but we do want to "certify"
some community bits against the productized bits.

Changes:

Add a generate-certified-bom mojo for generating a certified BOM.

It consumes (via a plugin dependency) a particular fraction-metadata,
along with a `certified.conf` in PWD listing the artifactId of the
items we desire to denote as certified.  In produces a :bom-certified
artifact which includes those things, plus our :arquillian fraction,
using the community version specified via the abovementioned
plugin dependency.

Result:

If used, another BOM.