### PR TITLE
SWARM-1362: boms/bom-certified should NOT contain the ShrinkWrap bits

### DIFF
--- a/src/main/java/org/wildfly/swarm/plugin/bom/BomBuilder.java
+++ b/src/main/java/org/wildfly/swarm/plugin/bom/BomBuilder.java
@@ -16,6 +16,7 @@
 package org.wildfly.swarm.plugin.bom;
 
 import java.util.Collection;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.apache.maven.project.MavenProject;
@@ -30,6 +31,9 @@ class BomBuilder {
                                      final String template,
                                      final Collection<DependencyMetadata> bomItems) {
 
+        String removeIfRegexp = "(?s)#\\{remove-if-" + Pattern.quote(rootProject.getArtifactId()) + "}.*?#\\{/remove-if-"
+                + Pattern.quote(rootProject.getArtifactId()) + "}\n?";
+
         return template.replace("#{dependencies}",
                                 String.join("\n",
                                             bomItems.stream()
@@ -37,7 +41,9 @@ class BomBuilder {
                                                     .collect(Collectors.toList())))
                 .replace("#{bom-artifactId}", rootProject.getArtifactId())
                 .replace("#{bom-name}", rootProject.getName())
-                .replace("#{bom-description}", rootProject.getDescription());
+                .replace("#{bom-description}", rootProject.getDescription())
+                .replaceAll(removeIfRegexp, "")
+                .replaceAll("#\\{/?remove-if-.*?}\n?", "");
 
     }
 


### PR DESCRIPTION
Motivation
----------
The template from which all the BOMs are created unconditionally
adds the ShrinkWrap pieces. However, the `bom-certified` shouldn't
contain them -- assuming there is a product, the main product BOM
would point to different version of the ShrinkWrap bits than
the certified BOM.

Modifications
-------------
The `BomBuilder` supports a directive `#{remove-if-artifact-id}`
whose content is removed when the BOM produced has certain
artifact ID.

Result
------
Able to remove ShrinkWrap dependencies from `bom-certified`.