### PR TITLE
SWARM-732: "Air Gap" repo

### DIFF
--- a/src/main/java/org/wildfly/swarm/plugin/repository/BomProjectBuilder.java
+++ b/src/main/java/org/wildfly/swarm/plugin/repository/BomProjectBuilder.java
@@ -32,15 +32,14 @@ class BomProjectBuilder {
 
     private static File preparePom(File bomFile, File generatedProject, File projectTemplate) throws Exception {
         String dependencies = extract(bomFile, "//dependencyManagement/dependencies/*")
+                .skipping("dependency-bom", "shrinkwrap")
                 .asString();
         String properties = extract(bomFile, "//properties/*").asString();
         String swarmVersion = extract(bomFile, "/project/version/text()").asString();
-        String bomArtifact = extract(bomFile, "/project/artifactId/text()").asString();
         String pomContent = readTemplate(projectTemplate)
                 .replace(DEPENDENCIES_PLACEHOLDER, dependencies)
                 .replace(PROPERTIES, properties)
-                .replace(SWARM_VERSION, swarmVersion)
-                .replace(BOM_ARTIFACT, bomArtifact);
+                .replace(SWARM_VERSION, swarmVersion);
         File pom = new File(generatedProject, "pom.xml");
         pom.createNewFile();
         try (FileWriter writer = new FileWriter(pom)) {


### PR DESCRIPTION
Motivation
----------
Provide repository of all artifacts needed to build a WF Swarm project.

Modifications
-------------
Improved the dependencies that we're brining in from the BOM, and fixed issue where it required BOM to be installed into M2 repo first.

Provide option to remove non -redhat artifacts from generated repo, as community artifacts are not required in zip for product.

Result
------
Improves slimming of M2 repo.