### PR TITLE
SWARM-1467: "runtime" modules should be marked private

### DIFF
--- a/src/main/java/org/wildfly/swarm/plugin/process/ModuleGenerator.java
+++ b/src/main/java/org/wildfly/swarm/plugin/process/ModuleGenerator.java
@@ -97,6 +97,8 @@ public class ModuleGenerator implements Function<FractionMetadata, FractionMetad
                 .name(moduleName)
                 .slot(RUNTIME);
 
+        markModulePrivate(runtimeModule);
+
         ArtifactType<ResourcesType<ModuleDescriptor>> runtimeArtifact = runtimeModule.getOrCreateResources().createArtifact();
         runtimeArtifact.name(this.project.getGroupId() + ":" + this.project.getArtifactId() + ":" + this.project.getVersion());
 
@@ -255,6 +257,10 @@ public class ModuleGenerator implements Function<FractionMetadata, FractionMetad
         export(apiModule, apiModuleXml);
         export(runtimeModule, runtimeModuleXml);
         export(deploymentModule, deploymentModuleXml);
+    }
+
+    private void markModulePrivate(ModuleDescriptor module) {
+        module.getOrCreateProperties().createProperty().name("jboss.api").value("private");
     }
 
     private void addDependencies(ModuleDescriptor module, List<String> dependencies) {


### PR DESCRIPTION
Motivation
----------
For each fraction, the `wildfly-swarm-fraction-plugin` generates
[up to] 4 modules (`module.xml`): `main`, `api`, `deployment` and
`runtime`. At the very least, the `runtime` one isn't supposed to
be used directly and compatibility isn't guaranteed. Those modules
should be marked _private_.

Modifications
-------------
Add the `jboss.api` property with value of `private` when generating
the `module.xml` for the `runtime` modules of all fractions.

Result
------
When user imports the `runtime` module of a fraction, they get
a friendly warning.