### PR TITLE
SWARM-1472: Arquillian fraction has test scope in all boms.

### DIFF
--- a/src/main/java/org/wildfly/swarm/plugin/AbstractFractionsMojo.java
+++ b/src/main/java/org/wildfly/swarm/plugin/AbstractFractionsMojo.java
@@ -35,6 +35,7 @@ import org.apache.maven.project.ProjectBuildingException;
 import org.apache.maven.project.ProjectBuildingRequest;
 import org.apache.maven.project.ProjectBuildingResult;
 import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.wildfly.swarm.plugin.DependencyMetadata.Scope;
 
 /**
  * @author Bob McWhirter
@@ -110,7 +111,7 @@ public abstract class AbstractFractionsMojo extends AbstractMojo {
     }
 
     protected FractionMetadata arquillianFraction(String version) {
-        return new FractionMetadata("org.wildfly.swarm", "arquillian", version);
+        return new FractionMetadata("org.wildfly.swarm", "arquillian", version, Scope.TEST.getValue());
     }
 
     @Inject

--- a/src/main/java/org/wildfly/swarm/plugin/DependencyMetadata.java
+++ b/src/main/java/org/wildfly/swarm/plugin/DependencyMetadata.java
@@ -1,6 +1,9 @@
 package org.wildfly.swarm.plugin;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * @author Bob McWhirter
@@ -17,20 +20,23 @@ public class DependencyMetadata {
 
     private final String packaging;
 
+    private final Scope scope;
+
     DependencyMetadata(FractionMetadata meta) {
-        this.groupId = meta.getGroupId();
-        this.artifactId = meta.getArtifactId();
-        this.version = meta.getVersion();
-        this.classifier = meta.getClassifier();
-        this.packaging = meta.getClassifier();
+        this(meta.getGroupId(), meta.getArtifactId(), meta.getVersion(), meta.getClassifier(), meta.getPackaging(), meta.getScope());
     }
 
     public DependencyMetadata(String groupId, String artifactId, String version, String classifier, String packaging) {
+        this(groupId, artifactId, version, classifier, packaging, null);
+    }
+
+    public DependencyMetadata(String groupId, String artifactId, String version, String classifier, String packaging, String scope) {
         this.groupId = groupId;
         this.artifactId = artifactId;
         this.version = version;
         this.classifier = classifier;
         this.packaging = packaging;
+        this.scope = Scope.of(scope);
     }
 
     public String getGroupId() {
@@ -55,8 +61,47 @@ public class DependencyMetadata {
         return this.packaging;
     }
 
+    @JsonIgnore
+    public String getScope() {
+        return scope.getValue();
+    }
+
+    @JsonIgnore
+    public boolean hasDefaultScope() {
+        return Scope.COMPILE.equals(scope);
+    }
+
+    @JsonInclude(value = Include.NON_NULL)
+    @JsonProperty("scope")
+    public String jsonScope() {
+        return hasDefaultScope() ? null : getScope();
+    }
+
     @Override
     public String toString() {
         return this.groupId + ":" + this.artifactId + ":" + this.packaging + (this.classifier == null ? "" : ":" + this.classifier) + ":" + this.version;
     }
+
+    enum Scope {
+
+        COMPILE, TEST, RUNTIME, PROVIDED, SYSTEM, IMPORT;
+
+        String getValue() {
+            return toString().toLowerCase();
+        }
+
+        static Scope of(String scope) {
+            if (scope != null) {
+                scope = scope.toUpperCase().trim();
+                for (Scope value : Scope.values()) {
+                    if (value.toString().equals(scope)) {
+                        return value;
+                    }
+                }
+            }
+            return COMPILE;
+        }
+
+    }
+
 }

--- a/src/main/java/org/wildfly/swarm/plugin/FractionMetadata.java
+++ b/src/main/java/org/wildfly/swarm/plugin/FractionMetadata.java
@@ -36,7 +36,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class FractionMetadata extends DependencyMetadata {
 
     public FractionMetadata(String groupId, String artifactId, String version) {
-        super(groupId, artifactId, version, null, "jar");
+        this(groupId, artifactId, version, null);
+    }
+
+    public FractionMetadata(String groupId, String artifactId, String version, String scope) {
+        super(groupId, artifactId, version, null, "jar", scope);
     }
 
     @JsonIgnore
@@ -219,6 +223,11 @@ public class FractionMetadata extends DependencyMetadata {
 
     public String toString() {
         return getGroupId() + ":" + getArtifactId() + ":" + this.getVersion();
+    }
+
+    @JsonIgnore
+    public String getFractionListString() {
+        return getGroupId() + ":" + getArtifactId() + ":" + this.getVersion() + (hasDefaultScope() ? "" : (":" + this.getScope()));
     }
 
     @JsonIgnore

--- a/src/main/java/org/wildfly/swarm/plugin/FractionRegistry.java
+++ b/src/main/java/org/wildfly/swarm/plugin/FractionRegistry.java
@@ -33,6 +33,8 @@ public class FractionRegistry {
 
     private static final String FRACTION_BOOTSTRAP_PROPERTY = "swarm.fraction.bootstrap";
 
+    private static final String FRACTION_SCOPE_PROPERTY_NAME = "swarm.fraction.scope";
+
     private static final String BOM_PROPERTY = "swarm.bom";
 
     private Map<Key, FractionMetadata> fractionRegistry = new HashMap<>();
@@ -70,7 +72,9 @@ public class FractionRegistry {
     }
 
     private FractionMetadata build(MavenProject project) {
-        FractionMetadata meta = new FractionMetadata(project.getGroupId(), project.getArtifactId(), project.getVersion());
+
+        FractionMetadata meta = new FractionMetadata(project.getGroupId(), project.getArtifactId(), project.getVersion(),
+                project.getProperties().getProperty(FRACTION_SCOPE_PROPERTY_NAME));
 
         meta.setName(project.getName());
         meta.setDescription(project.getDescription());
@@ -86,7 +90,6 @@ public class FractionRegistry {
             }
             meta.setStabilityIndex(stabilityLevel);
         }
-
 
         String tags = project.getProperties().getProperty(FRACTION_TAGS_PROPERTY_NAME);
         if (tags != null) {

--- a/src/main/java/org/wildfly/swarm/plugin/bom/BomBuilder.java
+++ b/src/main/java/org/wildfly/swarm/plugin/bom/BomBuilder.java
@@ -42,14 +42,12 @@ class BomBuilder {
     }
 
     private static String pomGav(DependencyMetadata project) {
-        return pomGav(project.getGroupId(), project.getArtifactId(), project.getVersion());
+        return String.format(DEP_TEMPLATE, project.getGroupId(), project.getArtifactId(), project.getVersion(),
+                project.hasDefaultScope() ? "" : "\n        <scope>" + project.getScope() + "</scope>");
     }
 
-    private static String pomGav(final String groupId, final String artifactId, final String version) {
-        return String.format(DEP_TEMPLATE, groupId, artifactId, version);
-    }
+    private static final String DEP_TEMPLATE = "      <dependency>\n        <groupId>%s</groupId>\n"
+            + "        <artifactId>%s</artifactId>\n        <version>%s</version>%s\n      </dependency>";
 
-    private static final String DEP_TEMPLATE = "      <dependency>\n        <groupId>%s</groupId>\n" +
-            "        <artifactId>%s</artifactId>\n        <version>%s</version>\n      </dependency>";
 }
 

--- a/src/main/java/org/wildfly/swarm/plugin/bom/CertifiedBomMojo.java
+++ b/src/main/java/org/wildfly/swarm/plugin/bom/CertifiedBomMojo.java
@@ -88,7 +88,7 @@ public class CertifiedBomMojo extends AbstractFractionsMojo {
                         })
                         .map(e -> {
                             String[] parts = e.split(":");
-                            return new FractionMetadata(parts[0], parts[1], parts[2]);
+                            return new FractionMetadata(parts[0], parts[1], parts[2], parts.length > 3 ? parts[3] : null);
                         })
                         .filter(e -> {
                             return certifiedFractions.contains(e.getArtifactId());

--- a/src/main/java/org/wildfly/swarm/plugin/fractionlist/FractionListMojo.java
+++ b/src/main/java/org/wildfly/swarm/plugin/fractionlist/FractionListMojo.java
@@ -69,7 +69,7 @@ public class FractionListMojo extends AbstractFractionsMojo {
 
         try (FileWriter out = new FileWriter(outFile)) {
             for (FractionMetadata each : fractions) {
-                out.write(each.toString());
+                out.write(each.getFractionListString());
                 out.write(" = ");
                 out.write(each.getDependenciesString());
                 out.write("\n");


### PR DESCRIPTION
Motivation
----------
Arquillian fraction should have "test" scope in all boms so that its
dependencies are not added to the resulting artifact during compilation.

Modifications
-------------
Added scope to FractionMetadata. Arquillian fraction is always added
with test scope. It is also possible to specify a default scope using
"swarm.fraction.scope" property in a fraction pom.

Result
------
Arquillian fraction has test scope in all boms.