### PR TITLE
ENTSWM-80 - Better javadocs

### DIFF
--- a/src/main/java/org/wildfly/swarm/plugin/bom/BomMojo.java
+++ b/src/main/java/org/wildfly/swarm/plugin/bom/BomMojo.java
@@ -88,6 +88,8 @@ public class BomMojo extends AbstractFractionsMojo {
         }
 
         project.setFile(bomPath.toFile());
+
+        getPluginContext().put("STABILITY_INDEX", this.stabilityIndex);
     }
 
     private String readTemplate() throws MojoFailureException {


### PR DESCRIPTION
Pass stability level through the plugin-context.
Doc-prep only the appropriately-leveled fractions (per BOM now).