### PR TITLE
SWARM-1599: fraction-metadata in BOM

### DIFF
--- a/src/main/java/org/wildfly/swarm/plugin/bom/BomMojo.java
+++ b/src/main/java/org/wildfly/swarm/plugin/bom/BomMojo.java
@@ -78,6 +78,7 @@ public class BomMojo extends AbstractFractionsMojo {
         }
 
         List<DependencyMetadata> bomItems = new ArrayList<>();
+        bomItems.add(new DependencyMetadata("org.wildfly.swarm", "fraction-metadata", this.project.getVersion(), null, "jar", "compile"));
         bomItems.addAll(fractions);
         bomItems.addAll(FractionRegistry.INSTANCE.bomInclusions());
         if (!this.product) {


### PR DESCRIPTION
Motivation
----------
To ensure that BuildTool uses the appropriate FractionUsageAnalyzer for auto detection, we need fraction-metadata present in the BOM.

Modifications
-------------
Modify BOM creation to add `fraction-metadata` by default to every BOM.

Result
------
`fraction-metadata` present in all BOMs.