### PR TITLE
SWARM-1619: BOM should not contain internal fractions

### DIFF
--- a/src/main/java/org/wildfly/swarm/plugin/bom/BomMojo.java
+++ b/src/main/java/org/wildfly/swarm/plugin/bom/BomMojo.java
@@ -54,7 +54,10 @@ public class BomMojo extends AbstractFractionsMojo {
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
-        Set<FractionMetadata> allFractions = fractions();
+        Set<FractionMetadata> allFractions = fractions()
+                .stream()
+                .filter(f -> !f.isInternal())
+                .collect(Collectors.toSet());
 
         Collection<FractionMetadata> fractions = null;
 


### PR DESCRIPTION
Motivation
----------
BOM should not contain internal fractions as their presence is not guaranteed and we don't want users adding them to their application directly.

Modifications
-------------
Filter list of fractions for non internal before determining stability of a fraction.

Result
------
Internal fractions no longer present in a BOM.