### PR TITLE
ENTSWM-261: changed repo zip generation to reference the bom

### DIFF
--- a/src/main/java/org/wildfly/swarm/plugin/repository/ProjectBuilderMojo.java
+++ b/src/main/java/org/wildfly/swarm/plugin/repository/ProjectBuilderMojo.java
@@ -40,7 +40,7 @@ public class ProjectBuilderMojo extends AbstractFractionsMojo {
                     throw new MojoFailureException("Unable to proceed without a `template` specified for generating a project pom.xml.");
                 }
 
-                repoPomFile = BomProjectBuilder.generateProject(projectDir, bomFile, template);
+                repoPomFile = BomProjectBuilder.generateProject(projectDir, bomFile, template, project);
                 if (!repoPomFile.exists()) {
                     throw new MojoFailureException("Failed to create project pom.xml");
                 }

--- a/src/main/java/org/wildfly/swarm/plugin/repository/RepositoryBuilderMojo.java
+++ b/src/main/java/org/wildfly/swarm/plugin/repository/RepositoryBuilderMojo.java
@@ -57,6 +57,8 @@ public class RepositoryBuilderMojo extends ProjectBuilderMojo {
                 }
             }
 
+            addBom();
+
             // Load project dependencies into local M2 repo
             executeGeneratedProjectBuild(repoPomFile, projectDir, repoDir);
 
@@ -64,7 +66,6 @@ public class RepositoryBuilderMojo extends ProjectBuilderMojo {
                 generateRuntimeDependenciesDescriptor();
             }
 
-            addBom();
             // Clear out unnecessary files from local M2 repo
             santizeRepo(repoDir.toPath());
 


### PR DESCRIPTION
The pom template for it will look as follows:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<!--  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates.  ~  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0  -->
<project xmlns="http://maven.apache.org/POM/4.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
  <modelVersion>4.0.0</modelVersion>
  <groupId>org.wildfly.swarm</groupId>
  <artifactId>wildfly-swarm-packaging-helper-project</artifactId>
  <version>1.0-SNAPSHOT</version>
  <packaging>war</packaging>

  <properties>
    <maven.compiler.source>1.8</maven.compiler.source>
    <maven.compiler.target>1.8</maven.compiler.target>
    PROPERTIES
  </properties>

  <dependencyManagement>
    <dependencies>
      <dependency>
        <groupId>BOM_GROUPID</groupId>
        <artifactId>BOM_ARTIFACT</artifactId>
        <version>SWARM_VERSION</version>
        <type>pom</type>
        <scope>import</scope>
      </dependency>
    </dependencies>
  </dependencyManagement>

  <dependencies>
    FRACTIONS_FROM_BOM
  </dependencies>

  <build>
    <finalName>full-project-package</finalName>
    <plugins>
      <plugin>
        <groupId>org.wildfly.swarm</groupId>
        <artifactId>wildfly-swarm-plugin</artifactId>
        <version>SWARM_VERSION</version>
        <executions>
          <execution>
            <goals>
              <goal>package</goal>
            </goals>
          </execution>
        </executions>
      </plugin>
      <plugin>
        <artifactId>maven-dependency-plugin</artifactId>
        <groupId>org.apache.maven.plugins</groupId>
        <version>2.10</version>
        <executions>
          <execution>
            <id>download-sources</id>
            <phase>prepare-package</phase>
            <goals>
              <goal>sources</goal>
            </goals>
          </execution>
        </executions>
      </plugin>
      <plugin>
        <artifactId>maven-war-plugin</artifactId>
        <version>2.6</version>
        <configuration>
          <failOnMissingWebXml>false</failOnMissingWebXml>
        </configuration>
      </plugin>
    </plugins>
  </build>

</project>

```