### PR TITLE
THORN-747: Don't serialize fraction-list.js dependencies

### DIFF
--- a/src/main/java/org/wildfly/swarm/plugin/FractionMetadata.java
+++ b/src/main/java/org/wildfly/swarm/plugin/FractionMetadata.java
@@ -36,6 +36,21 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 public class FractionMetadata extends DependencyMetadata {
 
+    public FractionMetadata(FractionMetadata metadata) {
+        super(metadata.getGroupId(), metadata.getArtifactId(), metadata.getVersion(), metadata.getClassifier(), metadata.getPackaging(),
+              metadata.getScope());
+        this.name = metadata.name;
+        this.description = metadata.description;
+        this.tags = metadata.tags;
+        this.internal = metadata.internal;
+        this.bootstrap = metadata.bootstrap;
+        this.moduleConf = metadata.moduleConf;
+        this.hasJavaCode = metadata.hasJavaCode;
+        this.javaFraction = metadata.javaFraction;
+        this.baseModulePath = metadata.baseModulePath;
+        this.stabilityIndex = metadata.stabilityIndex;
+    }
+
     public FractionMetadata(String groupId, String artifactId, String version) {
         this(groupId, artifactId, version, null);
     }

--- a/src/main/java/org/wildfly/swarm/plugin/fractionlist/FractionListMojo.java
+++ b/src/main/java/org/wildfly/swarm/plugin/fractionlist/FractionListMojo.java
@@ -120,6 +120,10 @@ public class FractionListMojo extends AbstractFractionsMojo {
     }
 
     private void generateJavascript(Set<FractionMetadata> fractions) {
+        Set<FractionMetadata> fractionsWithoutDeps = fractions.stream()
+                .map(FractionMetadata::new)
+                .collect(Collectors.toSet());
+
         ObjectMapper mapper = new ObjectMapper();
 
         mapper.configure(JsonGenerator.Feature.AUTO_CLOSE_TARGET, false);
@@ -131,7 +135,7 @@ public class FractionListMojo extends AbstractFractionsMojo {
             writer.write("fractionList = ");
             writer.flush();
 
-            mapper.writeValue(writer, fractions);
+            mapper.writeValue(writer, fractionsWithoutDeps);
 
             writer.write(";");
             writer.flush();


### PR DESCRIPTION
Motivation
----------
Consumers of fraction-list.js don't use the dependencies.

Modifications
-------------
Don't write out the dependencies into fraction-list.js

Result
------
No impact to product, only reduces JS file size read by generator.