### PR TITLE
THORN-2349: fraction plugin passes old system properties (swarm.*) when building offline Maven repository

### DIFF
--- a/src/main/java/org/wildfly/swarm/plugin/repository/BomProjectBuilder.java
+++ b/src/main/java/org/wildfly/swarm/plugin/repository/BomProjectBuilder.java
@@ -48,7 +48,9 @@ class BomProjectBuilder {
 
         String dependenciesAsString = Stream.of(bomFiles)
                 .flatMap(file -> getDependencies(file).stream())
+                .filter(XmlDependencyElement::isNormalDependency)
                 .map(XmlDependencyElement::getElementAsString)
+                .distinct()
                 .collect(Collectors.joining(NEWLINE));
 
         String pomContent = readTemplate(projectTemplate)

--- a/src/main/java/org/wildfly/swarm/plugin/repository/ProjectBuilder.java
+++ b/src/main/java/org/wildfly/swarm/plugin/repository/ProjectBuilder.java
@@ -6,6 +6,7 @@ import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -24,6 +25,7 @@ public class ProjectBuilder {
     }
 
     public File generateProject(File... bomFiles) throws MojoExecutionException {
+        log.info("Generating pom.xml from BOMs: " + Arrays.toString(bomFiles));
 
         try {
             // Initialize the project dir first
@@ -42,7 +44,7 @@ public class ProjectBuilder {
             if (!pomFile.exists()) {
                 throw new MojoFailureException("Failed to create project pom.xml");
             }
-            log.info("Generated pom.xml from BOM: " + pomFile.getAbsolutePath());
+            log.info("Generated pom.xml: " + pomFile.getAbsolutePath());
 
             return projectDir;
         } catch (Exception e) {
@@ -51,7 +53,9 @@ public class ProjectBuilder {
     }
 
     protected String projectName(File[] bomFiles) {
-        return "generated-project-" + Stream.of(bomFiles).map(File::getName).collect(Collectors.joining("_"));
+        return "generated-project_" + Stream.of(bomFiles)
+                .map(bomFile -> PomUtils.extract(bomFile, "/project/artifactId/text()").asString())
+                .collect(Collectors.joining("_"));
     }
 
     private final File template;

--- a/src/main/java/org/wildfly/swarm/plugin/repository/RepositoryBuilderMojo.java
+++ b/src/main/java/org/wildfly/swarm/plugin/repository/RepositoryBuilderMojo.java
@@ -190,11 +190,11 @@ public class RepositoryBuilderMojo extends AbstractFractionsMojo {
         Properties props = System.getProperties();
 
         if (Boolean.parseBoolean(downloadSources)) {
-            props.setProperty("swarm.download.sources", "");
+            props.setProperty("thorntail.download.sources", "");
         }
 
         if (Boolean.parseBoolean(downloadPoms)) {
-            props.setProperty("swarm.download.poms", "");
+            props.setProperty("thorntail.download.poms", "");
         }
 
         mavenRequest.setProperties(props);

--- a/src/main/java/org/wildfly/swarm/plugin/repository/XmlDependencyElement.java
+++ b/src/main/java/org/wildfly/swarm/plugin/repository/XmlDependencyElement.java
@@ -39,6 +39,7 @@ public class XmlDependencyElement {
 
     private String groupId;
     private String artifactId;
+    private String scope;
     private String elementAsString;
 
     static {
@@ -54,12 +55,17 @@ public class XmlDependencyElement {
         return elementAsString;
     }
 
+    public boolean isNormalDependency() {
+        return !"import".equals(scope); // `scope` can be `null`
+    }
+
     public static XmlDependencyElement fromNode(Node node, String elementAsString) {
         Map<String, String> map = toMap(node.getChildNodes());
 
         XmlDependencyElement result = new XmlDependencyElement();
         result.groupId = map.get("groupId");
         result.artifactId = map.get("artifactId");
+        result.scope = map.get("scope");
 
         result.elementAsString = elementAsString;
 


### PR DESCRIPTION
Motivation
----------
When building an offline Maven repository, the fraction plugin
passes system properties `swarm.download.sources` and
`swarm.download.poms` to the forked Maven build. However, that
forked Maven build expects the system properties to be named
`thorntail.*`. This means that the offline repository doesn't
contain source JARs and POMs.

Modifications
-------------
Fix names of the system properties.

In addition to that, this commit also slightly improves logging,
directory names for the artificial Maven projects used during
the offline Maven repo generation process, and makes sure this
artificial Maven project doesn't contain duplicate dependencies.

Result
------
Offline Maven repo will again contain source JARs and POMs.